### PR TITLE
Update Application states values

### DIFF
--- a/db/migrations/20201127123942-update-application-states.js
+++ b/db/migrations/20201127123942-update-application-states.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20201127123942-update-application-states-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20201127123942-update-application-states-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/db/migrations/sqls/20201127123942-update-application-states-down.sql
+++ b/db/migrations/sqls/20201127123942-update-application-states-down.sql
@@ -1,0 +1,119 @@
+INSERT INTO application_state(id, description)
+VALUES(1, 'Unprocessed')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;
+
+INSERT INTO application_state(id, description)
+VALUES(2, 'Pre-processing')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;
+
+INSERT INTO application_state(id, description)
+VALUES(3, 'Pre-processing - Awaiting info')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;
+
+INSERT INTO application_state(id, description)
+VALUES(4, 'Pre-processed')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;
+
+INSERT INTO application_state(id, description)
+VALUES(5, 'Pre-processing - Rejected')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;
+
+INSERT INTO application_state(id, description)
+VALUES(6, 'Processing')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;
+
+INSERT INTO application_state(id, description)
+VALUES(7, 'Panel Approved - Waiting for Bank Statement')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;
+
+INSERT INTO application_state(id, description)
+VALUES(8, 'Refer to Manager')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;
+
+INSERT INTO application_state(id, description)
+VALUES(9, 'Processing - Awaiting info')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;
+
+INSERT INTO application_state(id, description)
+VALUES(10, 'Processed - Panel Review')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;
+
+INSERT INTO application_state(id, description)
+VALUES(11, 'Processed - Rejected')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;
+
+INSERT INTO application_state(id, description)
+VALUES(12, 'Panel Approved')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;
+
+INSERT INTO application_state(id, description)
+VALUES(13, 'Panel Rejected')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;
+
+INSERT INTO application_state (id, description)
+VALUES(14, 'Closed - Duplicate')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;
+
+INSERT INTO application_state (id, description)
+VALUES(15, 'Closed - Resubmitting')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;
+
+INSERT INTO application_state(id, description)
+VALUES(16, 'Exported for Payment')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;
+
+INSERT INTO application_state(id, description)
+VALUES(17, 'Declined - Test')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;
+
+INSERT INTO application_state(id, description)
+VALUES(18, 'Panel Approved - Tier 2')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;
+
+INSERT INTO application_state(id, description)
+VALUES(19, 'Panel - Awaiting info')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;
+
+INSERT INTO application_state(id, description)
+VALUES(20, 'NFI Check')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;

--- a/db/migrations/sqls/20201127123942-update-application-states-up.sql
+++ b/db/migrations/sqls/20201127123942-update-application-states-up.sql
@@ -1,4 +1,4 @@
-DELETE FROM application_state WHERE id > 9;
+DELETE FROM application_state WHERE id > 10;
 
 INSERT INTO application_state(id, description)
 VALUES(1, 'Unprocessed')
@@ -13,43 +13,49 @@ DO UPDATE
 SET description = EXCLUDED.description;
 
 INSERT INTO application_state(id, description)
-VALUES(3, 'Pre-processed Review')
+VALUES(3, 'Pre-processed - Review')
 ON CONFLICT (id)
 DO UPDATE
 SET description = EXCLUDED.description;
 
 INSERT INTO application_state(id, description)
-VALUES(4, 'Refer to Manager')
+VALUES(4, 'Processed - Approved')
 ON CONFLICT (id)
 DO UPDATE
 SET description = EXCLUDED.description;
 
 INSERT INTO application_state(id, description)
-VALUES(5, 'Processed - Approved')
+VALUES(5, 'Processed - Rejected')
 ON CONFLICT (id)
 DO UPDATE
 SET description = EXCLUDED.description;
 
 INSERT INTO application_state(id, description)
-VALUES(6, 'Processed - Rejected')
+VALUES(6, 'NFI')
 ON CONFLICT (id)
 DO UPDATE
 SET description = EXCLUDED.description;
 
 INSERT INTO application_state(id, description)
-VALUES(7, 'NFI')
+VALUES(7, 'Refer to Manager')
 ON CONFLICT (id)
 DO UPDATE
 SET description = EXCLUDED.description;
 
 INSERT INTO application_state(id, description)
-VALUES(8, 'Exported for Payment')
+VALUES(8, 'Closed - Duplicate')
 ON CONFLICT (id)
 DO UPDATE
 SET description = EXCLUDED.description;
 
 INSERT INTO application_state(id, description)
-VALUES(9, 'Declined - Test')
+VALUES(9, 'Exported for Payment')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;
+
+INSERT INTO application_state(id, description)
+VALUES(10, 'Declined - Test')
 ON CONFLICT (id)
 DO UPDATE
 SET description = EXCLUDED.description;

--- a/db/migrations/sqls/20201127123942-update-application-states-up.sql
+++ b/db/migrations/sqls/20201127123942-update-application-states-up.sql
@@ -1,0 +1,55 @@
+DELETE FROM application_state WHERE id > 9;
+
+INSERT INTO application_state(id, description)
+VALUES(1, 'Unprocessed')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;
+
+INSERT INTO application_state(id, description)
+VALUES(2, 'Pre-processed')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;
+
+INSERT INTO application_state(id, description)
+VALUES(3, 'Pre-processed Review')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;
+
+INSERT INTO application_state(id, description)
+VALUES(4, 'Refer to Manager')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;
+
+INSERT INTO application_state(id, description)
+VALUES(5, 'Processed - Approved')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;
+
+INSERT INTO application_state(id, description)
+VALUES(6, 'Processed - Rejected')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;
+
+INSERT INTO application_state(id, description)
+VALUES(7, 'NFI')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;
+
+INSERT INTO application_state(id, description)
+VALUES(8, 'Exported for Payment')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;
+
+INSERT INTO application_state(id, description)
+VALUES(9, 'Declined - Test')
+ON CONFLICT (id)
+DO UPDATE
+SET description = EXCLUDED.description;

--- a/lib/dbMapping.js
+++ b/lib/dbMapping.js
@@ -64,25 +64,14 @@ export const STATE_AID_OPTION_WITH_MORE_Q = [
 
 export const APPLICATION_STATE = [
   'Unprocessed',
-  'Pre-processing',
-  'Pre-processing - Awaiting info',
   'Pre-processed',
-  'Pre-processing - Rejected',
-  'Processing',
-  'Panel Approved - Waiting for Bank Statement',
+  'Pre-processed Review',
   'Refer to Manager',
-  'Processing - Awaiting info',
-  'Processed - Panel Review',
+  'Processed - Approved',
   'Processed - Rejected',
-  'Panel Approved',
-  'Panel Rejected',
-  'Closed - Duplicate',
-  'Closed - Resubmitting',
+  'NFI',
   'Exported for Payment',
   'Declined - Test',
-  'Panel Approved - Tier 2',
-  'Panel - Awaiting info',
-  'NFI Check',
 ];
 export const GRANT_AMOUNT = ['0', '5000', '10000'];
 

--- a/lib/dbMapping.js
+++ b/lib/dbMapping.js
@@ -65,14 +65,16 @@ export const STATE_AID_OPTION_WITH_MORE_Q = [
 export const APPLICATION_STATE = [
   'Unprocessed',
   'Pre-processed',
-  'Pre-processed Review',
-  'Refer to Manager',
+  'Pre-processed - Review',
   'Processed - Approved',
   'Processed - Rejected',
   'NFI',
+  'Refer to Manager',
+  'Closed - Duplicate',
   'Exported for Payment',
   'Declined - Test',
 ];
+
 export const GRANT_AMOUNT = ['0', '5000', '10000'];
 
 export const BUSINESS_CATEGORIES = {

--- a/lib/usecases/listApplications.test.js
+++ b/lib/usecases/listApplications.test.js
@@ -198,7 +198,7 @@ describe('listApplications', () => {
     expect(databaseSpy).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        statesFilter: expect.arrayContaining([1, 2, 3, 4, 5, 6, 7, 8, 9]),
+        statesFilter: expect.arrayContaining([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
       })
     );
   });

--- a/lib/usecases/listApplications.test.js
+++ b/lib/usecases/listApplications.test.js
@@ -198,7 +198,7 @@ describe('listApplications', () => {
     expect(databaseSpy).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        statesFilter: expect.arrayContaining([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+        statesFilter: expect.arrayContaining([1, 2, 3, 4, 5, 6, 7, 8, 9]),
       })
     );
   });

--- a/lib/usecases/matchBusinessRatesNumber.js
+++ b/lib/usecases/matchBusinessRatesNumber.js
@@ -13,7 +13,7 @@ export const matchBusinessRatesNumber = async (businessRatesNumber) => {
 
   for (let i = 0; i < rows.length; i++) {
     if (businessRatesNumber == rows[i].account_id) {
-      return 4;
+      return 2;
     }
   }
 


### PR DESCRIPTION
This grant has a different processing flow, so this change updates the
application state values to reflect that flow.

The data has been changed in the migrations as that is where the initial
set up of application state was done, seeding with these values would
complicate this and affect migrations done in the future.

The migrate up (DELETE) won't work if any associations exist on the ids
above 9 exist, but as this is an initial set up I thought it would be OK
to have that in here.

