### PR TITLE
Change company number validation to 8 digits

### DIFF
--- a/components/Steps/index.jsx
+++ b/components/Steps/index.jsx
@@ -230,7 +230,7 @@ export const inputLabels = {
       validation: {
         required: true,
         pattern: {
-          value: /^[0-9]{11}$/,
+          value: /^[0-9]{8}$/,
         },
       },
     },


### PR DESCRIPTION
Company number is only 8 digits, fixing that typo in the validations.