### PR TITLE
Mutate formData Object to include businessIdentifyNumber

### DIFF
--- a/components/Steps/Summary.jsx
+++ b/components/Steps/Summary.jsx
@@ -14,6 +14,27 @@ const Result = ({ formData, clearFormData }) => {
   }, []);
   const submitForm = async () => {
     try {
+      const businessIdentifyingNums = [
+        'businessIdentifyNumberCompanyNumber',
+        'businessIdentifyNumberVAT',
+        'businessIdentifyNumberNIN',
+        'businessIdentifyNumberUTR',
+        'businessIdentifyNumber',
+      ];
+      for (let i = 0; i < businessIdentifyingNums.length; i++) {
+        console.log(i, formData.business[businessIdentifyingNums[i]]);
+        if (
+          Object.prototype.hasOwnProperty.call(
+            formData.business,
+            businessIdentifyingNums[i]
+          )
+        ) {
+          formData.business.businessIdentifyNumber =
+            formData.business[businessIdentifyingNums[i]];
+        }
+        console.log(formData.business);
+      }
+
       setSubmitting(true);
       const ref = await postApplication(formData);
       set(ref, formData);


### PR DESCRIPTION
Adding the validation on types of company number (using different inputs
for each type) meant that the form validation on the back end failed.

To to satisfy both from and back end validations, I'm looping through
all the possible company numbers and when the property existis in the
form data I assign that to `business.businessIdentifyNumber` in the formData
and pass that to satisfy the back end.

Not very happy with this fix, a better way of handling this is surely
possible but I can't think of it right now.

**What**  
{summarise your PR and what it is for, add a screenshot for UI changes}

**Why**  
{why are we making this change?}

**Anything else?**

- Have you added any new third-party libraries?
- Are any new environment variables or configuration values needed?
- Anything else in this PR that isn't covered by the what/why?
