### PR TITLE
Change company number to allow for 7 or 8 digits

### DIFF
--- a/components/Steps/index.jsx
+++ b/components/Steps/index.jsx
@@ -230,7 +230,7 @@ export const inputLabels = {
       validation: {
         required: true,
         pattern: {
-          value: /^\d{8}$/,
+          value: /^\d{7,8}$/,
         },
       },
     },


### PR DESCRIPTION
Company numbers in England and Wales can contain 8 digits, but can have
a leading 0, which some business users might not include. As it's easy
to rectify that if users only enter 7 digits - we should not block
on that validation.
