### PR TITLE
Update business company number regex pattern to accept alphanumeric

### DIFF
--- a/components/Steps/index.jsx
+++ b/components/Steps/index.jsx
@@ -230,7 +230,7 @@ export const inputLabels = {
       validation: {
         required: true,
         pattern: {
-          value: /^\d{7,8}$/,
+          value: /^\w{7,8}$/,
         },
       },
     },

--- a/components/Steps/index.jsx
+++ b/components/Steps/index.jsx
@@ -230,7 +230,7 @@ export const inputLabels = {
       validation: {
         required: true,
         pattern: {
-          value: /^\w{7,8}$/,
+          value: /^[a-zA-Z0-9]{7,8}$/,
         },
       },
     },


### PR DESCRIPTION
**What**  

- update RegEx pattern to allow alphanumeric characters
- DB accepts text, so no migrations are necessary

**Why**  

- company numbers can contain letters as well as digits