### PR TITLE
Remove truthy value check on admin form

### DIFF
--- a/components/Summary/Summary.jsx
+++ b/components/Summary/Summary.jsx
@@ -27,22 +27,20 @@ export const SummarySection = ({
     <SummaryList
       register={register}
       name={name}
-      list={Object.entries(formData[name])
-        .filter(([, value]) => value)
-        .map(([key, value]) => ({
-          key,
-          adminValidation: hasAdminValidation(name, key),
-          title: getInputProps(name, key).label,
-          value: Array.isArray(value)
-            ? value.filter(Boolean).map((v) => MultiValue(v.split('/').pop()))
-            : typeof value === 'object'
-            ? Object.values(value).filter(Boolean).map(MultiValue)
-            : typeof value === 'boolean'
-            ? value === true
-              ? 'Yes'
-              : 'No'
-            : value,
-        }))}
+      list={Object.entries(formData[name]).map(([key, value]) => ({
+        key,
+        adminValidation: hasAdminValidation(name, key),
+        title: getInputProps(name, key).label,
+        value: Array.isArray(value)
+          ? value.filter(Boolean).map((v) => MultiValue(v.split('/').pop()))
+          : typeof value === 'object'
+          ? Object.values(value).filter(Boolean).map(MultiValue)
+          : typeof value === 'boolean'
+          ? value === true
+            ? 'Yes'
+            : 'No'
+          : value,
+      }))}
     />
   );
   return (


### PR DESCRIPTION
The filter on this code means that only truthy values would be displayed
on the admin check form. However the admin people need to verify that
served_legal_notices checkbox is False, so we should just show everything
to resolve that. Only a few address fields and webiste address fields
will be shown to make the page longer, but this is a quick fix.