### PR TITLE
Persist query parameters on admin index page when clicking back link

### DIFF
--- a/components/ApplicationsList/ApplicationsList.jsx
+++ b/components/ApplicationsList/ApplicationsList.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
-import Router from 'next/router';
+import Router, { useRouter } from 'next/router';
 
 import Table from 'components/Table/Table';
 import ErrorMessage from 'components/ErrorMessage/ErrorMessage';
@@ -87,7 +87,7 @@ const ApplicationsList = ({
         sort: sortBy && `${sortBy.desc ? '-' : '+'}${sortBy.id}`,
         ...otherFilters,
       };
-      Router.push(
+      await Router.push(
         '/admin',
         {
           pathname: '/admin',
@@ -156,6 +156,7 @@ const ApplicationsList = ({
       )}
 
       <TextInput
+        name="searchByApplicationId"
         label="Search by Application ID"
         value={filters.applicationId}
         onChange={(applicationIdEvent) => {
@@ -209,5 +210,12 @@ const ApplicationsList = ({
     <ErrorMessage text={error} />
   );
 };
+
+export function getQueryParametersAsObject() {
+  const nextRouter = useRouter();
+  const queryString = nextRouter.asPath.split(/\?/)[1];
+
+  return Object.fromEntries(new URLSearchParams(queryString));
+}
 
 export default ApplicationsList;

--- a/components/Table/Table.jsx
+++ b/components/Table/Table.jsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import Router from 'next/router';
 import { useTable, useSortBy, usePagination } from 'react-table';
+import { getQueryParametersAsObject } from '../ApplicationsList/ApplicationsList.jsx';
 
 const Table = ({
   columns,
@@ -80,15 +81,19 @@ const Table = ({
         <tbody className="govuk-table__body" {...getTableBodyProps()}>
           {page.map((row) => {
             prepareRow(row);
+            const queryParameters = getQueryParametersAsObject();
             return (
               <tr
                 className="govuk-table__row lbh-table__row--data"
                 {...row.getRowProps()}
                 onClick={() =>
-                  Router.push(
-                    '/admin/applications/[clientGeneratedId]',
-                    `/admin/applications/${row.original.clientGeneratedId}`
-                  )
+                  Router.push({
+                    pathname: '/admin/applications/[clientGeneratedId]',
+                    query: {
+                      clientGeneratedId: row.original.clientGeneratedId,
+                      ...queryParameters,
+                    },
+                  })
                 }
               >
                 {row.cells.map((cell) => {

--- a/pages/admin/applications/[clientGeneratedId].js
+++ b/pages/admin/applications/[clientGeneratedId].js
@@ -5,13 +5,20 @@ import ApplicationView from 'components/ApplicationView/ApplicationView';
 
 const ApplicationViewPage = () => {
   const router = useRouter();
-  const { clientGeneratedId } = router.query;
+  const { clientGeneratedId, ...queryParameters } = router.query;
   return (
     <>
       <a
         className="govuk-back-link"
         role="button"
-        onClick={() => router.back()}
+        onClick={() =>
+          router.push({
+            pathname: '/admin',
+            query: {
+              ...queryParameters,
+            },
+          })
+        }
       >
         Back
       </a>


### PR DESCRIPTION
**What**  

- add function to get query parameters as object
- pass the query parameter object to application view
- persist filtering on admin index page

**Why**  

- filters were reset when clicking back link
- `router.back()` works differently than expected, as it does not persist the query parameters when clicking the back link