### PR TITLE
Show export state in ApplicationsList

### DIFF
--- a/components/ApplicationsList/ApplicationsList.jsx
+++ b/components/ApplicationsList/ApplicationsList.jsx
@@ -38,6 +38,11 @@ const ApplicationsList = ({
         Cell: ({ value }) => new Date(value).toLocaleString(),
       },
       {
+        Header: 'Exported for payment',
+        accessor: 'exported',
+        disableSortBy: true,
+      },
+      {
         Header: 'Status',
         accessor: 'status',
         disableSortBy: true,

--- a/components/ApplicationsList/ApplicationsList.jsx
+++ b/components/ApplicationsList/ApplicationsList.jsx
@@ -38,7 +38,7 @@ const ApplicationsList = ({
         Cell: ({ value }) => new Date(value).toLocaleString(),
       },
       {
-        Header: 'Exported for payment',
+        Header: 'Exported for Payment',
         accessor: 'exported',
         disableSortBy: true,
       },

--- a/lib/usecases/listApplications.js
+++ b/lib/usecases/listApplications.js
@@ -46,6 +46,9 @@ const listApplications = ({ getDbInstance, getListGrantOfficers }) => async ({
       ga.client_generated_id,
       b.business_name,
       state.description AS status,
+      aa.lrsg_closed_businesses_payment_exported AS closed_grant_exported,
+      aa.lrsg_open_payment_exported AS open_grant_exported,
+      aa.lrsg_sector_payment_exported AS sector_grant_exported,
       COUNT(*) OVER() AS total_applications
     FROM
       grant_application AS ga
@@ -89,12 +92,23 @@ const listApplications = ({ getDbInstance, getListGrantOfficers }) => async ({
   }
 
   return {
-    applications: applications.map((application) => ({
-      clientGeneratedId: application.client_generated_id,
-      businessName: application.business_name,
-      applicationDate: new Date(application.date_time_recorded).toISOString(),
-      status: application.status,
-    })),
+    applications: applications.map((application) => {
+      const lrsg_closed = application.closed_grant_exported
+        ? 'LSRG Closed '
+        : '';
+      const lrsg_open = application.open_grant_exported ? 'LSRG Open ' : '';
+      const lrsg_sector = application.sector_grant_exported
+        ? 'LSRG Sector '
+        : '';
+      const exported_grants = `${lrsg_closed}${lrsg_open}${lrsg_sector}`;
+      return {
+        clientGeneratedId: application.client_generated_id,
+        businessName: application.business_name,
+        applicationDate: new Date(application.date_time_recorded).toISOString(),
+        status: application.status,
+        exported: exported_grants,
+      };
+    }),
     pagination: {
       totalPages,
       currentPage,

--- a/lib/usecases/listApplications.js
+++ b/lib/usecases/listApplications.js
@@ -93,14 +93,18 @@ const listApplications = ({ getDbInstance, getListGrantOfficers }) => async ({
 
   return {
     applications: applications.map((application) => {
-      const lrsg_closed = application.closed_grant_exported
-        ? 'LSRG Closed '
-        : '';
-      const lrsg_open = application.open_grant_exported ? 'LSRG Open ' : '';
-      const lrsg_sector = application.sector_grant_exported
-        ? 'LSRG Sector '
-        : '';
-      const exported_grants = `${lrsg_closed}${lrsg_open}${lrsg_sector}`;
+      const exported_grants_array = [];
+      if (application.closed_grant_exported) {
+        exported_grants_array.push('LSRG Closed');
+      }
+      if (application.open_grant_exported) {
+        exported_grants_array.push('LSRG Open');
+      }
+      if (application.sector_grant_exported) {
+        exported_grants_array.push('LSRG Sector');
+      }
+      const exported_grants = exported_grants_array.join(', ');
+
       return {
         clientGeneratedId: application.client_generated_id,
         businessName: application.business_name,

--- a/lib/usecases/listApplications.test.js
+++ b/lib/usecases/listApplications.test.js
@@ -70,14 +70,14 @@ describe('listApplications', () => {
       businessName: 'Business Name 1',
       applicationDate: '2020-06-16T06:16:19.640Z',
       status: 'Unprocessed',
-      exported: 'LSRG Closed LSRG Open LSRG Sector ',
+      exported: 'LSRG Closed, LSRG Open, LSRG Sector',
     });
     expect(applications[9]).toEqual({
       clientGeneratedId: 'ClientGeneratedId10',
       businessName: 'Business Name 10',
       applicationDate: '2020-06-16T06:16:19.640Z',
       status: 'Unprocessed',
-      exported: 'LSRG Closed LSRG Open LSRG Sector ',
+      exported: 'LSRG Closed, LSRG Open, LSRG Sector',
     });
   });
 

--- a/lib/usecases/listApplications.test.js
+++ b/lib/usecases/listApplications.test.js
@@ -10,6 +10,9 @@ function createContainerAndSpies(numberOfApplicationsInResponse) {
       client_generated_id: `ClientGeneratedId${count}`,
       business_name: `Business Name ${count}`,
       status: 'Unprocessed',
+      closed_grant_exported: true,
+      open_grant_exported: true,
+      sector_grant_exported: true,
     });
   }
 
@@ -67,12 +70,14 @@ describe('listApplications', () => {
       businessName: 'Business Name 1',
       applicationDate: '2020-06-16T06:16:19.640Z',
       status: 'Unprocessed',
+      exported: 'LSRG Closed LSRG Open LSRG Sector ',
     });
     expect(applications[9]).toEqual({
       clientGeneratedId: 'ClientGeneratedId10',
       businessName: 'Business Name 10',
       applicationDate: '2020-06-16T06:16:19.640Z',
       status: 'Unprocessed',
+      exported: 'LSRG Closed LSRG Open LSRG Sector ',
     });
   });
 


### PR DESCRIPTION
As the 3 different grants can be exported independently, this should
help agents filter grant applications that need reviewing for different
grant types from the application list page.


![image](https://user-images.githubusercontent.com/436713/101163322-5e636d00-362b-11eb-9e91-1c4dea9f2cf5.png)
