### PR TITLE
Removed Jan 05 question

### DIFF
--- a/components/Steps/EligibilityCriteriaDetails.jsx
+++ b/components/Steps/EligibilityCriteriaDetails.jsx
@@ -115,7 +115,7 @@ const Step1 = (props) => {
             trading on the day before the relevant local restriction period came
             into effect.
           </span>
-          <Radios
+          {/*  <Radios
             {...getInputProps(
               'eligibilityCriteriaDetails',
               'tradingOn040121Cycle2',
@@ -125,7 +125,7 @@ const Step1 = (props) => {
               errors
             )}
             onChange={() => setShowError(false)}
-          />
+          /> */}
           <Radios
             {...getInputProps(
               'eligibilityCriteriaDetails',


### PR DESCRIPTION
Requirement below:

We need to remove the below question currently included within the form, as that grant is closing at the end of the month. 

Does your business meet the following criteria for the Local Restrictions Support Grant (Closed) Addendum: 5 January onwards?
Business was required to close by the Government under the national lockdown which started on 5th January 2021, including non-essential retail, hospitality, accommodation, leisure, personal care, and gym businesses. . See guidance on business closures in England.
Business was trading on the day before local restrictions came into effect (i.e on the 4th January 2021).
Please note if your business was closed on the 4 January 2021 as a result of Government COVID-19 restrictions but would otherwise have been open and trading then you are considered to have been trading on the 4 January 2021.