### PR TITLE
Add a permit step before deploying staging infrastructure resources.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,15 +121,19 @@ workflows:
           type: approval
           requires:
             - build-deploy-staging
+      - are-you-sure:
+          type: approval
+          requires:
+            - permit-deploy-production
       - assume-role-production:
           context: api-cloud-engineering-deployment-context
           requires:
             - install-dependencies-and-test
-            - permit-deploy-production
+            - are-you-sure
           filters:
             branches:
               only: master
       - build-deploy-production:
           requires:
-            - permit-deploy-production
+            - are-you-sure
             - assume-role-production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,10 @@ workflows:
           type: approval
           requires:
             - install-dependencies-and-test
+          filters:
+            branches:
+              only:
+                - master
       - assume-role-staging:
           context: api-cloud-engineering-deployment-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,10 +94,14 @@ workflows:
   continuous-delivery:
     jobs:
       - install-dependencies-and-test
+      - permit-deploy-staging:
+          type: approval
+          requires:
+            - install-dependencies-and-test
       - assume-role-staging:
           context: api-cloud-engineering-deployment-context
           requires:
-            - install-dependencies-and-test
+            - permit-deploy-staging
           filters:
             branches:
               only: master


### PR DESCRIPTION
# What:
 - Add a manual permit requirement before deploying staging resources.

# Why:
 - We don't want for the pipeline to trigger before we're ready, especially given we're planning on destroying cloud resources.