### PR TITLE
Cap serverless framework version to v3 instead.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
       - *attach_workspace
       - run:
           name: deploy
-          command: yarn build && yarn --production=true && sudo npm i -g serverless && sls deploy --stage staging
+          command: yarn build && yarn --production=true && sudo npm i -g serverless@^3 && sls deploy --stage staging
           no_output_timeout: 45m
 
   build-deploy-production:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
       - *attach_workspace
       - run:
           name: deploy
-          command: yarn build && yarn --production=true && sudo npm i -g serverless && sls deploy --stage production
+          command: yarn build && yarn --production=true && sudo npm i -g serverless@^3 && sls deploy --stage production
           no_output_timeout: 45m
 
   assume-role-staging:


### PR DESCRIPTION
# What:
 - Limit installed serverless version to major version 3.

# Why:
 - Version 4 requires paid license, which requires an account & login to be able to use the package.