### PR TITLE
Retire `staging` environment resources due to the environment being no longer relevant.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
       - *attach_workspace
       - run:
           name: deploy
-          command: yarn build && yarn --production=true && sudo npm i -g serverless@^3 && sls deploy --stage staging
+          command: yarn build && yarn --production=true && sudo npm i -g serverless@^3 && sls remove --stage staging
           no_output_timeout: 45m
 
   build-deploy-production:

--- a/serverless.yml
+++ b/serverless.yml
@@ -84,6 +84,7 @@ resources:
   Resources:
     covidBusinessGrantsSupportingDocumentsBucket:
         Type: AWS::S3::Bucket
+        DeletionPolicy: Retain
         Properties:
           BucketName: ${self:custom.bucket}
           PublicAccessBlockConfiguration:


### PR DESCRIPTION
# What:
 - Trigger the `staging` environment's resource destruction.
 - This PR is also a test to see whether the `DeletionPolicy: Retain` works as expected with `sls remove`.

# Why:
 - The environment is not used. It's meant for development, but there's no development - app is decommissioned.

# Notes:
 - The URLs have been retired within this [PR #93](https://github.com/LBHackney-IT/ce-dns/pull/93/files#diff-8a773aaef3a7fd762dd8a42d52bd15483e4a4686f3d2301e418d38e62d0b698bL1645-L1651), however, the staging URL seems to have been retired long since.
 - If the `staging` S3 bucket doesn't get deleted via this PR _(should test succeed)_, then it will be removed in the follow up PR.  

# Screenshots:
**Front end not being used**:

| Staging environment is no longer accessible via URL as the app is decommissioned. | Production decommissioning message |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/3c8042d0-3cf6-4aa7-a0c8-3d054bd213b9) | ![image](https://github.com/user-attachments/assets/a835828d-4da3-4bb6-b742-7c861797781e) |

**Database not being used**:

| Staging database not in use for 15 months | S3 staging bucket contains only dummy development data |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/9227cd4e-ab5f-4953-80be-b84706c1c8d5) | ![image](https://github.com/user-attachments/assets/2a515188-8935-41b2-b632-a03acba3d712) |