### PR TITLE
Change deploy job's executor from AWS CLI to Node.js

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           paths: .
 
   build-deploy-staging:
-    executor: aws-cli/default
+    executor: node-executor
     steps:
       - *attach_workspace
       - run:
@@ -54,7 +54,7 @@ jobs:
           no_output_timeout: 45m
 
   build-deploy-production:
-    executor: aws-cli/default
+    executor: node-executor
 
     steps:
       - *attach_workspace


### PR DESCRIPTION
# What:
 - Change deploy job's executor from AWS CLI to Node.js

# Why:
 - The AWS CLI executor possibly defaults to the latest node version, which according to the failing pipeline is `Node.js v20.11.1`. Needless to say, this ancient app does not seem to be compatible with a node version so many Major versions ahead since the last time it was developed.

# Notes:
 - Expecting that pipeline may still fail due to CCI's executor node version being too old for the latest releases of serverless version v3.