### PR TITLE
Bump `circleci/node` executor from Node.js v12 to v14 to get latest v3 version of Serverless working.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 executors:
   node-executor:
     docker:
-      - image: circleci/node:12.9.1-browsers
+      - image: circleci/node:14.17.1-browsers
   docker-python:
     docker:
       - image: circleci/python:3.7


### PR DESCRIPTION
# What:
 - Bump the deprecated `circleci/node:a.b.c-browsers` convenience docker image executor from v12 to v14.

# Why:
 - This image is being used by both the install & test step as well as by deploy step that installs serverless. Serverless v3 requires using Node.js v14.0.0 at minimum.

# Notes:
 - Using a deprecated image as there's no need to mess around with the newer `cimg/node` versions due to this repository about to be archived. We'll remove the pipeline promptly before that.
 - Follow up to the #69 .
 - Actual error:
```
+ serverless@3.39.0
added 580 packages from 357 contributors in 25.121s
Error: Serverless Framework v3 does not support Node.js v12.9.1. Please upgrade Node.js to the latest LTS version (v14.0.0 is a minimum supported version)
```