### PR TITLE
Fix pipeline complaining about missing packages.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           root: *workspace_root
           paths: .
 
-  build-deploy-staging:
+  build-deploy-delete-staging:
     executor: node-executor
     steps:
       - *attach_workspace
@@ -118,7 +118,7 @@ workflows:
           filters:
             branches:
               only: master
-      - build-deploy-staging:
+      - build-deploy-delete-staging:
           requires:
             - install-dependencies-and-test
             - assume-role-staging
@@ -129,7 +129,7 @@ workflows:
       - permit-deploy-production:
           type: approval
           requires:
-            - build-deploy-staging
+            - build-deploy-delete-staging
       - are-you-sure:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,8 +49,17 @@ jobs:
     steps:
       - *attach_workspace
       - run:
-          name: deploy
-          command: yarn build && yarn --production=true && sudo npm i -g serverless@^3 && sls remove --stage staging
+          name: build
+          command: yarn build
+      - run:
+          name: wtf
+          command: yarn --production=true
+      - run:
+          name: install sls
+          command: sudo npm i -g serverless@^3
+      - run:
+          name: delete
+          command: sls remove --stage staging
           no_output_timeout: 45m
 
   build-deploy-production:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,9 +52,6 @@ jobs:
           name: build
           command: yarn build
       - run:
-          name: wtf
-          command: yarn --production=true
-      - run:
           name: install sls
           command: sudo npm i -g serverless@^3
       - run:


### PR DESCRIPTION
# What:
 - Expand the staging build step into multiple commands for ease of debug.
 - Remove potentially unneeded & failing yarn step.

# Why:
 - The pipeline is failing with an error that some package is missing during the install process of one of those 4 commands being chained together with &&.
 - The 2nd yarn command is possibly not needed due to yarn build installing what's needed already.
 - Rename the job.