### PR TITLE
Update `circleci/node` from v14 to v16.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 executors:
   node-executor:
     docker:
-      - image: circleci/node:14.17.1-browsers
+      - image: circleci/node:16.9.1-browsers
   docker-python:
     docker:
       - image: circleci/python:3.7


### PR DESCRIPTION
# What:
 - Update the CCI node executor version from 14 to 16.

# Why:
 - Seems that serverless v3.16+ has some issues with node v14, which results in the `Error: Cannot find module 'node:events'` error.