### PR TITLE
Undo `Regen-Apps-Staging` account specific serverless definitions.

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -127,7 +127,7 @@ resources:
       Type: AWS::RDS::DBInstance
       Properties:
         AllocatedStorage: 5
-        DBInstanceIdentifier: "covid-business-grants-db-${self:provider.stage}"
+        DBInstanceIdentifier: "covid-business-grants-db-${self:provider.stage}-updated"
         DBInstanceClass: "db.t2.small"
         #DBName: ${self:provider.dbname}
         DeletionProtection: false

--- a/serverless.yml
+++ b/serverless.yml
@@ -129,7 +129,7 @@ resources:
         AllocatedStorage: 5
         DBInstanceIdentifier: "covid-business-grants-db-${self:provider.stage}-updated"
         DBInstanceClass: "db.t2.small"
-        #DBName: ${self:provider.dbname}
+        DBName: ${self:provider.dbname}
         DeletionProtection: false
         Engine: "postgres"
         EngineVersion: "11.12"

--- a/serverless.yml
+++ b/serverless.yml
@@ -116,7 +116,6 @@ resources:
           FromPort: '5432'
           ToPort: '5432'
           CidrIp: 0.0.0.0/0
-        VpcId: ${self:custom.vpcs.${self:provider.stage}}
 
     covidBusinessGrantsRDSSubnetGroup:
       Type: AWS::RDS::DBSubnetGroup

--- a/serverless.yml
+++ b/serverless.yml
@@ -126,7 +126,6 @@ resources:
     covidBusinessGrantsDbUpdated:
       Type: AWS::RDS::DBInstance
       Properties:
-        DBSnapshotIdentifier: ${self:custom.rds-snapshot.${self:provider.stage}}
         AllocatedStorage: 5
         DBInstanceIdentifier: "covid-business-grants-db-${self:provider.stage}"
         DBInstanceClass: "db.t2.small"


### PR DESCRIPTION
# What:
- Remove the VpcId property from Db security group.
- Remove the RDS Db snapshot identifier.
- Correct RDS postgres DB instance identifier.
- Bring back RDS Instance DBName.

# Why:
 - All of these changes were specific to the Regen Apps Staging account.
 - We're targeting serverless to the StagingAPIs account as that's where the application and its data was finally moved to.

