### PR TITLE
Fixes and Tweaks for `Regen-Apps-Staging` pipeline for resource retiring.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ jobs:
     executor: node-executor
     steps:
       - *attach_workspace
+      - aws-cli/install
       - checkout
       - run:
           name: install sls

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,9 +48,7 @@ jobs:
     executor: node-executor
     steps:
       - *attach_workspace
-      - run:
-          name: build
-          command: yarn build
+      - checkout
       - run:
           name: install sls
           command: sudo npm i -g serverless@^3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ workflows:
       - assume-role-production:
           context: api-cloud-engineering-deployment-context
           requires:
-            - install-dependencies-and-test
+            # - install-dependencies-and-test
             - are-you-sure
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ workflows:
           #     only:
           #       - master
       - assume-role-staging:
-          context: api-assume-role-staging-context
+          context: api-assume-role-regen-apps-staging-context
           requires:
             - permit-deploy-staging
           # filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,21 @@ jobs:
           name: install sls
           command: sudo npm i -g serverless@^3
       - run:
+          name: clear bucket
+          command: |
+            bucket_name="covid-business-grants-regen-supporting-documents-staging"
+            aws s3 rm "s3://$bucket_name" --recursive
+
+            aws s3api list-object-versions --bucket $bucket_name --query 'Versions[].[Key,VersionId]' --output text | \
+            while IFS=$'\t' read -r key version_id; do
+              aws s3api delete-object --bucket $bucket_name --key "$key" --version-id "$version_id"
+            done
+
+            aws s3api list-object-versions --bucket $bucket_name --query 'DeleteMarkers[].[Key,VersionId]' --output text | \
+            while IFS=$'\t' read -r key version_id; do
+              aws s3api delete-object --bucket $bucket_name --key "$key" --version-id "$version_id"
+            done
+      - run:
           name: delete
           command: sls remove --stage staging
           no_output_timeout: 45m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
           command: sudo npm i -g serverless@^3
       - run:
           name: delete
-          command: sls deploy --stage staging
+          command: sls remove --stage staging
           no_output_timeout: 45m
 
   build-deploy-production:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,30 +99,30 @@ workflows:
   version: 2
   continuous-delivery:
     jobs:
-      - install-dependencies-and-test
+      # - install-dependencies-and-test
       - permit-deploy-staging:
           type: approval
-          requires:
-            - install-dependencies-and-test
-          filters:
-            branches:
-              only:
-                - master
+          # requires:
+          #   - install-dependencies-and-test
+          # filters:
+          #   branches:
+          #     only:
+          #       - master
       - assume-role-staging:
           context: api-assume-role-staging-context
           requires:
             - permit-deploy-staging
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
       - build-deploy-delete-staging:
           requires:
-            - install-dependencies-and-test
+            # - install-dependencies-and-test
             - assume-role-staging
-          filters:
-            branches:
-              only:
-                - master
+          # filters:
+          #   branches:
+          #     only:
+          #       - master
       - permit-deploy-production:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,12 +61,14 @@ jobs:
 
             aws s3api list-object-versions --bucket $bucket_name --query 'Versions[].[Key,VersionId]' --output text | \
             while IFS=$'\t' read -r key version_id; do
-              aws s3api delete-object --bucket $bucket_name --key "$key" --version-id "$version_id"
+              echo -e "K: #$key#, V: #$version_id#"
+              # aws s3api delete-object --bucket $bucket_name --key "$key" --version-id "$version_id"
             done
 
             aws s3api list-object-versions --bucket $bucket_name --query 'DeleteMarkers[].[Key,VersionId]' --output text | \
             while IFS=$'\t' read -r key version_id; do
-              aws s3api delete-object --bucket $bucket_name --key "$key" --version-id "$version_id"
+              echo -e "K: #$key#, V: #$version_id#"
+              # aws s3api delete-object --bucket $bucket_name --key "$key" --version-id "$version_id"
             done
       - run:
           name: delete

--- a/serverless.yml
+++ b/serverless.yml
@@ -17,7 +17,7 @@ resources:
   Resources:
     covidBusinessGrantsSupportingDocumentsBucket:
         Type: AWS::S3::Bucket
-        DeletionPolicy: Retain
+        # DeletionPolicy: Retain
         Properties:
           BucketName: ${self:custom.bucket}
           PublicAccessBlockConfiguration:

--- a/serverless.yml
+++ b/serverless.yml
@@ -148,13 +148,11 @@ custom:
     production: vpc-0c9c2cbf1865adb9e
   subnets:
     staging:
-      - subnet-07e8364b
-      - subnet-723cb408
-      - subnet-48094621
+      - subnet-034d259953e54531a
+      - subnet-0e0152a2fc2b42498
     production:
-      - subnet-034b2a03cd4955923
-      - subnet-03431a6c898502c99
-      - subnet-0f02c86bab1d62956
+      - subnet-067865bb76395b74e
+      - subnet-056356c011224f114
   allowed-groups:
     staging: 'Covid Business Grants (Mandatory) - Staging'
     production: 'Covid Business Grants (Mandatory)'

--- a/serverless.yml
+++ b/serverless.yml
@@ -17,7 +17,7 @@ resources:
   Resources:
     covidBusinessGrantsSupportingDocumentsBucket:
         Type: AWS::S3::Bucket
-        # DeletionPolicy: Retain
+        DeletionPolicy: Retain
         Properties:
           BucketName: ${self:custom.bucket}
           PublicAccessBlockConfiguration:


### PR DESCRIPTION
# What:
 - Clear the S3 Bucket.
 - Disable & Re-enable the S3 Retain policy _(for staging retirement purposes)_.
 - Bring back regen apps subnets.
 - Remove install & build dependency from staging workflow. 

# Why:
 - To be able to fully retire unused application & its stack within the `Regen-Apps-Staging` environment.
 - S3 Retain flicker because we only want to remove the staging S3 bucket.

# Notes:
 - This PR is closely related to the PR #76 .
 - This PR's sole purpose is to squash merge trial & error as well as temporary commits changes.