### PR TITLE
Retire the `Regen-Apps-Staging` environment resources.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,15 +48,31 @@ jobs:
     executor: node-executor
     steps:
       - *attach_workspace
-      - run:
-          name: build
-          command: yarn build
+      - aws-cli/install
+      - checkout
       - run:
           name: install sls
           command: sudo npm i -g serverless@^3
       - run:
+          name: clear bucket
+          command: |
+            bucket_name="covid-business-grants-regen-supporting-documents-staging"
+            aws s3 rm "s3://$bucket_name" --recursive
+
+            aws s3api list-object-versions --bucket $bucket_name --query 'Versions[].[Key,VersionId]' --output text | \
+            while IFS=$'\t' read -r key version_id; do
+              echo -e "K: #$key#, V: #$version_id#"
+              # aws s3api delete-object --bucket $bucket_name --key "$key" --version-id "$version_id"
+            done
+
+            aws s3api list-object-versions --bucket $bucket_name --query 'DeleteMarkers[].[Key,VersionId]' --output text | \
+            while IFS=$'\t' read -r key version_id; do
+              echo -e "K: #$key#, V: #$version_id#"
+              # aws s3api delete-object --bucket $bucket_name --key "$key" --version-id "$version_id"
+            done
+      - run:
           name: delete
-          command: sls deploy --stage staging
+          command: sls remove --stage staging
           no_output_timeout: 45m
 
   build-deploy-production:
@@ -99,30 +115,30 @@ workflows:
   version: 2
   continuous-delivery:
     jobs:
-      - install-dependencies-and-test
+      # - install-dependencies-and-test
       - permit-deploy-staging:
           type: approval
-          requires:
-            - install-dependencies-and-test
-          filters:
-            branches:
-              only:
-                - master
+          # requires:
+          #   - install-dependencies-and-test
+          # filters:
+          #   branches:
+          #     only:
+          #       - master
       - assume-role-staging:
-          context: api-assume-role-staging-context
+          context: api-assume-role-regen-apps-staging-context
           requires:
             - permit-deploy-staging
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
       - build-deploy-delete-staging:
           requires:
-            - install-dependencies-and-test
+            # - install-dependencies-and-test
             - assume-role-staging
-          filters:
-            branches:
-              only:
-                - master
+          # filters:
+          #   branches:
+          #     only:
+          #       - master
       - permit-deploy-production:
           type: approval
           requires:
@@ -134,7 +150,7 @@ workflows:
       - assume-role-production:
           context: api-cloud-engineering-deployment-context
           requires:
-            - install-dependencies-and-test
+            # - install-dependencies-and-test
             - are-you-sure
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
     steps:
       - checkout
       - aws_assume_role/assume_role:
-          account: $AWS_ACCOUNT_STAGING
+          account: $AWS_ACCOUNT_REGEN_APPS_STAGING
           profile_name: default
           role: "LBH_Circle_CI_Deployment_Role"
       - persist_to_workspace:

--- a/serverless.yml
+++ b/serverless.yml
@@ -141,8 +141,8 @@ custom:
     staging: staging-covidbusinessgrants.hackney.gov.uk
     production: covidbusinessgrants.hackney.gov.uk
   certificate-arn:
-    staging: arn:aws:acm:us-east-1:715003523189:certificate/8f7fa30c-a4e5-4775-b827-ade824a33c9a
-    production: arn:aws:acm:us-east-1:153306643385:certificate/71728a39-cd3e-4570-a440-e87f84ef9a0d
+    staging: arn:aws:acm:us-east-1:647298111750:certificate/a9c099b9-50bb-411b-84e3-982ffa1c76bf
+    production: arn:aws:acm:us-east-1:812721144296:certificate/f0ad1b83-2a2d-4073-9a1e-fc614fa2eb94
   vpcs:
     staging: vpc-0047c1ec06d524b64
     production: vpc-0c9c2cbf1865adb9e

--- a/serverless.yml
+++ b/serverless.yml
@@ -148,13 +148,11 @@ custom:
     production: vpc-0c9c2cbf1865adb9e
   subnets:
     staging:
-      - subnet-07e8364b
-      - subnet-723cb408
-      - subnet-48094621
+      - subnet-034d259953e54531a
+      - subnet-0e0152a2fc2b42498
     production:
-      - subnet-034b2a03cd4955923
-      - subnet-03431a6c898502c99
-      - subnet-0f02c86bab1d62956
+      - subnet-067865bb76395b74e
+      - subnet-056356c011224f114
   allowed-groups:
     staging: 'Covid Business Grants (Mandatory) - Staging'
     production: 'Covid Business Grants (Mandatory)'

--- a/serverless.yml
+++ b/serverless.yml
@@ -125,7 +125,11 @@ resources:
                 OriginProtocolPolicy: https-only
 
 custom:
-  bucket: ${self:service}-supporting-documents-${self:provider.stage}
+  # bucket: ${self:service}-supporting-documents-${self:provider.stage}
+  bucket: ${self:service}-regen-supporting-documents-${self:provider.stage}
+  rds-snapshot:
+    staging: arn:aws:rds:eu-west-2:647298111750:snapshot:restored-grants-db
+    production: arn:aws:rds:eu-west-2:812721144296:snapshot:cbg-snapshot-final
   domain-name:
     Fn::Join:
       - '.'

--- a/serverless.yml
+++ b/serverless.yml
@@ -49,6 +49,7 @@ resources:
           FromPort: '5432'
           ToPort: '5432'
           CidrIp: 0.0.0.0/0
+        VpcId: ${self:custom.vpcs.${self:provider.stage}}
 
     covidBusinessGrantsRDSSubnetGroup:
       Type: AWS::RDS::DBSubnetGroup
@@ -58,11 +59,12 @@ resources:
 
     covidBusinessGrantsDbUpdated:
       Type: AWS::RDS::DBInstance
+      DBSnapshotIdentifier: ${self:custom.rds-snapshot.${self:provider.stage}}
       Properties:
         AllocatedStorage: 5
-        DBInstanceIdentifier: "covid-business-grants-db-${self:provider.stage}-updated"
+        DBInstanceIdentifier: "covid-business-grants-db-${self:provider.stage}"
         DBInstanceClass: "db.t2.small"
-        DBName: ${self:provider.dbname}
+        # DBName: ${self:provider.dbname}
         DeletionProtection: false
         Engine: "postgres"
         EngineVersion: "11.12"
@@ -137,6 +139,9 @@ custom:
   certificate-arn:
     staging: arn:aws:acm:us-east-1:715003523189:certificate/8f7fa30c-a4e5-4775-b827-ade824a33c9a
     production: arn:aws:acm:us-east-1:153306643385:certificate/71728a39-cd3e-4570-a440-e87f84ef9a0d
+  vpcs:
+    staging: vpc-0047c1ec06d524b64
+    production: vpc-0c9c2cbf1865adb9e
   subnets:
     staging:
       - subnet-07e8364b


### PR DESCRIPTION
# What:
 - Attempt to retire `Regen-Apps-Staging` environment duplicate _(of `StagingAPIs`)_ CloudFormation stack.

# Why:
 - The application has been long decommissioned. #67 
 - There's no active development, so `staging` environment has no worth.
 - There's no valuable data within staging environment. The RDS instance has been deleted long ago, so it's only the S3 bucket that's left. This bucket contains solely dummy and test data.

# Screenshots:

| Regen-Apps-Staging S3 bucket dummy data examples |
| --- |
| ![image](https://github.com/user-attachments/assets/ed44668a-9a14-452c-97d6-2dd052f64c86) |