### PR TITLE
Remove `staging` pipeline steps.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,84 +19,14 @@ references:
       at: *workspace_root
 
 jobs:
-  install-dependencies-and-test:
-    executor: node-executor
-    steps:
-      - *attach_workspace
-      - checkout
-      - run:
-          name: Install dependencies
-          command: yarn
-
-      - run:
-          name: Build the application
-          command: yarn build
-
-      - run:
-          name: Run unit tests
-          command: yarn run unit-test
-
-      - run:
-          name: Run linting
-          command: yarn lint
-
-      - persist_to_workspace:
-          root: *workspace_root
-          paths: .
-
-  build-deploy-delete-staging:
-    executor: node-executor
-    steps:
-      - *attach_workspace
-      - aws-cli/install
-      - checkout
-      - run:
-          name: install sls
-          command: sudo npm i -g serverless@^3
-      - run:
-          name: clear bucket
-          command: |
-            bucket_name="covid-business-grants-regen-supporting-documents-staging"
-            aws s3 rm "s3://$bucket_name" --recursive
-
-            aws s3api list-object-versions --bucket $bucket_name --query 'Versions[].[Key,VersionId]' --output text | \
-            while IFS=$'\t' read -r key version_id; do
-              echo -e "K: #$key#, V: #$version_id#"
-              # aws s3api delete-object --bucket $bucket_name --key "$key" --version-id "$version_id"
-            done
-
-            aws s3api list-object-versions --bucket $bucket_name --query 'DeleteMarkers[].[Key,VersionId]' --output text | \
-            while IFS=$'\t' read -r key version_id; do
-              echo -e "K: #$key#, V: #$version_id#"
-              # aws s3api delete-object --bucket $bucket_name --key "$key" --version-id "$version_id"
-            done
-      - run:
-          name: delete
-          command: sls remove --stage staging
-          no_output_timeout: 45m
-
   build-deploy-production:
     executor: node-executor
-
     steps:
       - *attach_workspace
       - run:
           name: deploy
           command: yarn build && yarn --production=true && sudo npm i -g serverless@^3 && sls deploy --stage production
           no_output_timeout: 45m
-
-  assume-role-staging:
-    executor: docker-python
-    steps:
-      - checkout
-      - aws_assume_role/assume_role:
-          account: $AWS_ACCOUNT_REGEN_APPS_STAGING
-          profile_name: default
-          role: "LBH_Circle_CI_Deployment_Role"
-      - persist_to_workspace:
-          root: *workspace_root
-          paths:
-            - .aws
 
   assume-role-production:
     executor: docker-python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,10 +47,16 @@ workflows:
     jobs:
       - permit-deploy-production:
           type: approval
+          filters:
+            branches:
+              only: master
       - are-you-sure:
           type: approval
           requires:
             - permit-deploy-production
+          filters:
+            branches:
+              only: master
       - assume-role-production:
           context: api-cloud-engineering-deployment-context
           requires:
@@ -62,3 +68,6 @@ workflows:
           requires:
             - are-you-sure
             - assume-role-production
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,8 +71,6 @@ workflows:
           #       - master
       - permit-deploy-production:
           type: approval
-          requires:
-            - build-deploy-delete-staging
       - are-you-sure:
           type: approval
           requires:
@@ -80,7 +78,6 @@ workflows:
       - assume-role-production:
           context: api-cloud-engineering-deployment-context
           requires:
-            # - install-dependencies-and-test
             - are-you-sure
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,30 +45,6 @@ workflows:
   version: 2
   continuous-delivery:
     jobs:
-      # - install-dependencies-and-test
-      - permit-deploy-staging:
-          type: approval
-          # requires:
-          #   - install-dependencies-and-test
-          # filters:
-          #   branches:
-          #     only:
-          #       - master
-      - assume-role-staging:
-          context: api-assume-role-regen-apps-staging-context
-          requires:
-            - permit-deploy-staging
-          # filters:
-          #   branches:
-          #     only: master
-      - build-deploy-delete-staging:
-          requires:
-            # - install-dependencies-and-test
-            - assume-role-staging
-          # filters:
-          #   branches:
-          #     only:
-          #       - master
       - permit-deploy-production:
           type: approval
       - are-you-sure:


### PR DESCRIPTION
# What:
 - Remove `staging` pipeline remnants.

# Why:
 - Resources within both the `StagingAPIs` and the `Regen-Apps-Staging` environments were already retired.

# Notes:
See PRs:
 1. PR #67 
 2. PR #77 