### PR TITLE
Deploy Supporting Document S3 Bucket Retain Delete Policy to `Regen-Apps-Production` account.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ workflows:
             branches:
               only: master
       - assume-role-production:
-          context: api-cloud-engineering-deployment-context
+          context: api-assume-role-regen-apps-production-context
           requires:
             - are-you-sure
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,13 @@ jobs:
     executor: node-executor
     steps:
       - *attach_workspace
+      - checkout
+      - run:
+          name: install
+          command: sudo npm i -g serverless@^3
       - run:
           name: deploy
-          command: yarn build && yarn --production=true && sudo npm i -g serverless@^3 && sls deploy --stage production
+          command: sls deploy --stage production
           no_output_timeout: 45m
 
   assume-role-production:

--- a/serverless.yml
+++ b/serverless.yml
@@ -57,33 +57,33 @@ resources:
         DBSubnetGroupDescription: "RDS Subnet Group"
         SubnetIds: ${self:custom.subnets.${self:provider.stage}}
 
-    covidBusinessGrantsDbUpdated:
-      Type: AWS::RDS::DBInstance
-      DBSnapshotIdentifier: ${self:custom.rds-snapshot.${self:provider.stage}}
-      Properties:
-        AllocatedStorage: 5
-        DBInstanceIdentifier: "covid-business-grants-db-${self:provider.stage}"
-        DBInstanceClass: "db.t2.small"
-        # DBName: ${self:provider.dbname}
-        DeletionProtection: false
-        Engine: "postgres"
-        EngineVersion: "11.12"
-        MasterUsername: ${env:MASTER_USERNAME}
-        MasterUserPassword: ${env:MASTER_USER_PASSWORD}
-        MultiAZ: true
-        PubliclyAccessible: false
-        StorageEncrypted: true
-        VPCSecurityGroups:
-        - Fn::GetAtt:
-          - covidBusinessGrantsDbSecurityGroup
-          - GroupId
-        DBSubnetGroupName:
-          Ref: covidBusinessGrantsRDSSubnetGroup
-        Tags:
-          -
-            Key: "Name"
-            Value: "covidBusinessGrantsDbUpdated"
-      DeletionPolicy: Delete
+    # covidBusinessGrantsDbUpdated:
+    #   Type: AWS::RDS::DBInstance
+    #   DBSnapshotIdentifier: ${self:custom.rds-snapshot.${self:provider.stage}}
+    #   Properties:
+    #     AllocatedStorage: 5
+    #     DBInstanceIdentifier: "covid-business-grants-db-${self:provider.stage}"
+    #     DBInstanceClass: "db.t2.small"
+    #     # DBName: ${self:provider.dbname}
+    #     DeletionProtection: false
+    #     Engine: "postgres"
+    #     EngineVersion: "11.12"
+    #     MasterUsername: ${env:MASTER_USERNAME}
+    #     MasterUserPassword: ${env:MASTER_USER_PASSWORD}
+    #     MultiAZ: true
+    #     PubliclyAccessible: false
+    #     StorageEncrypted: true
+    #     VPCSecurityGroups:
+    #     - Fn::GetAtt:
+    #       - covidBusinessGrantsDbSecurityGroup
+    #       - GroupId
+    #     DBSubnetGroupName:
+    #       Ref: covidBusinessGrantsRDSSubnetGroup
+    #     Tags:
+    #       -
+    #         Key: "Name"
+    #         Value: "covidBusinessGrantsDbUpdated"
+    #   DeletionPolicy: Delete
 
 custom:
   # bucket: ${self:service}-supporting-documents-${self:provider.stage}

--- a/serverless.yml
+++ b/serverless.yml
@@ -85,64 +85,12 @@ resources:
             Value: "covidBusinessGrantsDbUpdated"
       DeletionPolicy: Delete
 
-    CloudFrontDistribution:
-      Type: AWS::CloudFront::Distribution
-      Properties:
-        DistributionConfig:
-          Aliases:
-            - ${self:custom.aliases.${self:provider.stage}}
-          PriceClass: PriceClass_100
-          ViewerCertificate:
-            AcmCertificateArn: ${self:custom.certificate-arn.${self:provider.stage}}
-            MinimumProtocolVersion: TLSv1.2_2018
-            SslSupportMethod: sni-only
-          DefaultCacheBehavior:
-            TargetOriginId: ${self:service}-${self:provider.stage}-custom-origin
-            ViewerProtocolPolicy: 'redirect-to-https'
-            AllowedMethods:
-              - GET
-              - HEAD
-              - OPTIONS
-              - PUT
-              - PATCH
-              - POST
-              - DELETE
-            DefaultTTL: 0
-            MaxTTL: 0
-            MinTTL: 0
-            ForwardedValues:
-              QueryString: true
-              Cookies:
-                Forward: all
-          Enabled: true
-          Origins:
-            - Id: ${self:service}-${self:provider.stage}-custom-origin
-              DomainName: ${self:custom.domain-name}
-              OriginPath: /${self:provider.stage}
-              CustomOriginConfig:
-                HTTPPort: 80
-                HTTPSPort: 443
-                OriginProtocolPolicy: https-only
-
 custom:
   # bucket: ${self:service}-supporting-documents-${self:provider.stage}
   bucket: ${self:service}-regen-supporting-documents-${self:provider.stage}
   rds-snapshot:
     staging: arn:aws:rds:eu-west-2:647298111750:snapshot:restored-grants-db
     production: arn:aws:rds:eu-west-2:812721144296:snapshot:cbg-snapshot-final
-  domain-name:
-    Fn::Join:
-      - '.'
-      - - Ref: ApiGatewayRestApi
-        - execute-api
-        - eu-west-2
-        - amazonaws.com
-  aliases:
-    staging: staging-covidbusinessgrants.hackney.gov.uk
-    production: covidbusinessgrants.hackney.gov.uk
-  certificate-arn:
-    staging: arn:aws:acm:us-east-1:647298111750:certificate/a9c099b9-50bb-411b-84e3-982ffa1c76bf
-    production: arn:aws:acm:us-east-1:812721144296:certificate/f0ad1b83-2a2d-4073-9a1e-fc614fa2eb94
   vpcs:
     staging: vpc-0047c1ec06d524b64
     production: vpc-0c9c2cbf1865adb9e
@@ -153,6 +101,3 @@ custom:
     production:
       - subnet-067865bb76395b74e
       - subnet-056356c011224f114
-  allowed-groups:
-    staging: 'Covid Business Grants (Mandatory) - Staging'
-    production: 'Covid Business Grants (Mandatory)'


### PR DESCRIPTION
# What:
 - Tweak the `production` pipeline to point and work with `Regen-Apps-Production` account.
 - Remove the CloudFront distribution configuration (CFD).
 - Commented out the RDS instance configuration.

# Why:
 - CFD change as we expect to encounter the same API GW referencing issues we did  on arg-grants.
 - No RDS config as this database was destroyed by CE team on `Regen-Apps-Production`, but not on `ProductionAPIs`. So don't want to recreate it on `Regen-Apps-Production` with this deployment.

# Notes:
 - The Deletion Policies were change in the previous PR: #67 
 - This change will trigger the destruction of lambdas as their config was removed in PR #74 
 - It will also remove the CFD.
