### PR TITLE
Retire the `Regen-Apps-Production` resources except for S3 supporting docs bucket.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           command: sudo npm i -g serverless@^3
       - run:
           name: deploy
-          command: sls deploy --stage production
+          command: sls remove --verbose --stage production
           no_output_timeout: 45m
 
   assume-role-production:


### PR DESCRIPTION
# What:
 - Make the pipeline remove the `covid-business-grants-production` resources in the `Regen-Apps-Production` account.

# Why:
 - The application has been long decommissioned.

# Notes:
 - We're retaining the S3 supporting documents bucket to preserve data as its deletion was not agreed on.
 - See more details in PR #79 .

# Screenshot

| S3 regen apps bucket has retain policy deployed |
| --- |
| ![image](https://github.com/user-attachments/assets/e66448c2-2989-4efe-a773-281d974d96d7) |