### PR TITLE
Delete `production` serverless deployment bucket

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,16 +20,22 @@ references:
 
 jobs:
   build-deploy-production:
-    executor: node-executor
+    executor: aws-cli/default
     steps:
       - *attach_workspace
+      - aws-cli/install
       - checkout
       - run:
           name: install
           command: sudo npm i -g serverless@^3
       - run:
           name: deploy
-          command: sls remove --verbose --stage production
+          command:
+            # sls remove --verbose --stage production
+            
+            bucket_name="covid-business-grants-pr-serverlessdeploymentbuck-193fpskx8va0u"
+            aws s3 rm "s3://$bucket_name" --recursive
+            aws s3api delete-bucket --bucket $bucket_name
           no_output_timeout: 45m
 
   assume-role-production:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           command: sudo npm i -g serverless@^3
       - run:
           name: deploy
-          command:
+          command: |
             # sls remove --verbose --stage production
             
             bucket_name="covid-business-grants-pr-serverlessdeploymentbuck-193fpskx8va0u"


### PR DESCRIPTION
# What

- This PR makes the pipeline delete the serverless deployment S3 bucket.

# Why

- This deployment bucket does not actually contain the serverless files but instead seems to just hold AWS patch console outputs. This is stopping the applications CloudFormation stack from being deleted so we have to delete this S3 bucket through the pipeline.