### PR TITLE
Repoint from `Regen-Apps-Production` to `ProductionAPIs` & Deploy "preserve S3".

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,23 +55,16 @@ workflows:
           filters:
             branches:
               only: master
-      - are-you-sure:
-          type: approval
+
+      - assume-role-production:
+          context: api-assume-role-production-context
           requires:
             - permit-deploy-production
           filters:
             branches:
               only: master
-      - assume-role-production:
-          context: api-assume-role-production-context
-          requires:
-            - are-you-sure
-          filters:
-            branches:
-              only: master
       - build-deploy-production:
           requires:
-            - are-you-sure
             - assume-role-production
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - checkout
       - aws_assume_role/assume_role:
-          account: $AWS_ACCOUNT_REGEN_APPS_PRODUCTION
+          account: $AWS_ACCOUNT_PRODUCTION
           profile_name: default
           role: "LBH_Circle_CI_Deployment_Role"
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,12 +30,7 @@ jobs:
           command: sudo npm i -g serverless@^3
       - run:
           name: deploy
-          command: |
-            # sls remove --verbose --stage production
-            
-            bucket_name="covid-business-grants-pr-serverlessdeploymentbuck-193fpskx8va0u"
-            aws s3 rm "s3://$bucket_name" --recursive
-            aws s3api delete-bucket --bucket $bucket_name
+          command: sls deploy --verbose --stage production
           no_output_timeout: 45m
 
   assume-role-production:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ workflows:
             branches:
               only: master
       - assume-role-production:
-          context: api-assume-role-regen-apps-production-context
+          context: api-assume-role-production-context
           requires:
             - are-you-sure
           filters:

--- a/serverless.yml
+++ b/serverless.yml
@@ -59,15 +59,15 @@ resources:
 
     covidBusinessGrantsDbUpdated:
       Type: AWS::RDS::DBInstance
-      DBSnapshotIdentifier: ${self:custom.rds-snapshot.${self:provider.stage}}
       Properties:
         AllocatedStorage: 5
-        DBInstanceIdentifier: "covid-business-grants-db-${self:provider.stage}"
-        DBInstanceClass: "db.t2.small"
-        # DBName: ${self:provider.dbname}
+        DBInstanceIdentifier: "covid-business-grants-db-${self:provider.stage}-updated"
+        CACertificateIdentifier: 'rds-ca-rsa2048-g1'
+        DBInstanceClass: "db.t3.small"
+        DBName: ${self:provider.dbname}
         DeletionProtection: false
         Engine: "postgres"
-        EngineVersion: "11.12"
+        EngineVersion: "11.22"
         MasterUsername: ${env:MASTER_USERNAME}
         MasterUserPassword: ${env:MASTER_USER_PASSWORD}
         MultiAZ: true
@@ -80,9 +80,12 @@ resources:
         DBSubnetGroupName:
           Ref: covidBusinessGrantsRDSSubnetGroup
         Tags:
-          -
-            Key: "Name"
+          - Key: "Name"
             Value: "covidBusinessGrantsDbUpdated"
+          - Key: "BackupPolicy"
+            Value: "Prod"
+          - Key: "STAGE"
+            Value: ${self:provider.stage}
       DeletionPolicy: Delete
 
 custom:

--- a/serverless.yml
+++ b/serverless.yml
@@ -49,7 +49,6 @@ resources:
           FromPort: '5432'
           ToPort: '5432'
           CidrIp: 0.0.0.0/0
-        VpcId: ${self:custom.vpcs.${self:provider.stage}}
 
     covidBusinessGrantsRDSSubnetGroup:
       Type: AWS::RDS::DBSubnetGroup
@@ -89,18 +88,11 @@ resources:
       DeletionPolicy: Delete
 
 custom:
-  # bucket: ${self:service}-supporting-documents-${self:provider.stage}
-  bucket: ${self:service}-regen-supporting-documents-${self:provider.stage}
-  rds-snapshot:
-    staging: arn:aws:rds:eu-west-2:647298111750:snapshot:restored-grants-db
-    production: arn:aws:rds:eu-west-2:812721144296:snapshot:cbg-snapshot-final
+  bucket: ${self:service}-supporting-documents-${self:provider.stage}
   vpcs:
-    staging: vpc-0047c1ec06d524b64
     production: vpc-0c9c2cbf1865adb9e
   subnets:
-    staging:
-      - subnet-034d259953e54531a
-      - subnet-0e0152a2fc2b42498
     production:
-      - subnet-067865bb76395b74e
-      - subnet-056356c011224f114
+      - subnet-034b2a03cd4955923
+      - subnet-03431a6c898502c99
+      - subnet-0f02c86bab1d62956

--- a/serverless.yml
+++ b/serverless.yml
@@ -57,33 +57,33 @@ resources:
         DBSubnetGroupDescription: "RDS Subnet Group"
         SubnetIds: ${self:custom.subnets.${self:provider.stage}}
 
-    # covidBusinessGrantsDbUpdated:
-    #   Type: AWS::RDS::DBInstance
-    #   DBSnapshotIdentifier: ${self:custom.rds-snapshot.${self:provider.stage}}
-    #   Properties:
-    #     AllocatedStorage: 5
-    #     DBInstanceIdentifier: "covid-business-grants-db-${self:provider.stage}"
-    #     DBInstanceClass: "db.t2.small"
-    #     # DBName: ${self:provider.dbname}
-    #     DeletionProtection: false
-    #     Engine: "postgres"
-    #     EngineVersion: "11.12"
-    #     MasterUsername: ${env:MASTER_USERNAME}
-    #     MasterUserPassword: ${env:MASTER_USER_PASSWORD}
-    #     MultiAZ: true
-    #     PubliclyAccessible: false
-    #     StorageEncrypted: true
-    #     VPCSecurityGroups:
-    #     - Fn::GetAtt:
-    #       - covidBusinessGrantsDbSecurityGroup
-    #       - GroupId
-    #     DBSubnetGroupName:
-    #       Ref: covidBusinessGrantsRDSSubnetGroup
-    #     Tags:
-    #       -
-    #         Key: "Name"
-    #         Value: "covidBusinessGrantsDbUpdated"
-    #   DeletionPolicy: Delete
+    covidBusinessGrantsDbUpdated:
+      Type: AWS::RDS::DBInstance
+      DBSnapshotIdentifier: ${self:custom.rds-snapshot.${self:provider.stage}}
+      Properties:
+        AllocatedStorage: 5
+        DBInstanceIdentifier: "covid-business-grants-db-${self:provider.stage}"
+        DBInstanceClass: "db.t2.small"
+        # DBName: ${self:provider.dbname}
+        DeletionProtection: false
+        Engine: "postgres"
+        EngineVersion: "11.12"
+        MasterUsername: ${env:MASTER_USERNAME}
+        MasterUserPassword: ${env:MASTER_USER_PASSWORD}
+        MultiAZ: true
+        PubliclyAccessible: false
+        StorageEncrypted: true
+        VPCSecurityGroups:
+        - Fn::GetAtt:
+          - covidBusinessGrantsDbSecurityGroup
+          - GroupId
+        DBSubnetGroupName:
+          Ref: covidBusinessGrantsRDSSubnetGroup
+        Tags:
+          -
+            Key: "Name"
+            Value: "covidBusinessGrantsDbUpdated"
+      DeletionPolicy: Delete
 
 custom:
   # bucket: ${self:service}-supporting-documents-${self:provider.stage}


### PR DESCRIPTION
# What:
 - Repoint the pipeline to the `ProductionAPIs` AWS account.
 - Remove the `Regen-Apps-Production` specific resource properties.
 - Replace the `Regen-Apps-Production` specific resource properties with `ProductionAPIs` ones.
 - Make the pipeline deploy instead of remove.

# Why:
 - We want to deploy the S3 Bucket retention policy to the `ProductionAPIs` account.
 - We want to deploy the removal of RDS deletion protection to the same account.

# Notes:
 - For more details refer to the PR: #79  as we're doing the same thing, but a different account due to resource duplication between these accounts.
 - The deployment will remove lambdas and cloud front distribution, but again read the above linked PR.