### PR TITLE
Remove`production` database

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -50,43 +50,6 @@ resources:
           ToPort: '5432'
           CidrIp: 0.0.0.0/0
 
-    covidBusinessGrantsRDSSubnetGroup:
-      Type: AWS::RDS::DBSubnetGroup
-      Properties:
-        DBSubnetGroupDescription: "RDS Subnet Group"
-        SubnetIds: ${self:custom.subnets.${self:provider.stage}}
-
-    covidBusinessGrantsDbUpdated:
-      Type: AWS::RDS::DBInstance
-      Properties:
-        AllocatedStorage: 5
-        DBInstanceIdentifier: "covid-business-grants-db-${self:provider.stage}-updated"
-        CACertificateIdentifier: 'rds-ca-rsa2048-g1'
-        DBInstanceClass: "db.t3.small"
-        DBName: ${self:provider.dbname}
-        DeletionProtection: false
-        Engine: "postgres"
-        EngineVersion: "11.22"
-        MasterUsername: ${env:MASTER_USERNAME}
-        MasterUserPassword: ${env:MASTER_USER_PASSWORD}
-        MultiAZ: true
-        PubliclyAccessible: false
-        StorageEncrypted: true
-        VPCSecurityGroups:
-        - Fn::GetAtt:
-          - covidBusinessGrantsDbSecurityGroup
-          - GroupId
-        DBSubnetGroupName:
-          Ref: covidBusinessGrantsRDSSubnetGroup
-        Tags:
-          - Key: "Name"
-            Value: "covidBusinessGrantsDbUpdated"
-          - Key: "BackupPolicy"
-            Value: "Prod"
-          - Key: "STAGE"
-            Value: ${self:provider.stage}
-      DeletionPolicy: Delete
-
 custom:
   bucket: ${self:service}-supporting-documents-${self:provider.stage}
   vpcs:


### PR DESCRIPTION
# What

- Removes resource definition for RDS database from Serverless.

# Why

| Application has been retired and database hasn't been connected to in 15 months |
| --- |
| ![image](https://github.com/user-attachments/assets/98a7c57f-4cd4-417e-a78d-afd3736b0b2d) |
