### PR TITLE
Modify pipeline to remove production resources.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,14 +23,13 @@ jobs:
     executor: aws-cli/default
     steps:
       - *attach_workspace
-      - aws-cli/install
       - checkout
       - run:
           name: install
           command: sudo npm i -g serverless@^3
       - run:
           name: deploy
-          command: sls deploy --verbose --stage production
+          command: sls remove --verbose --stage production
           no_output_timeout: 45m
 
   assume-role-production:


### PR DESCRIPTION
# What:
 - Retire `ProductionAPIs` **covid-business-grants-production** CloudFormation stack resources _(except S3)_.

# Why:
 - The application has been long decommissioned _(See screenshots on PR #67 )_.

# Notes:
 - The S3 will not be destroyed & will get de'associated from the stack due to previously deployed [Retain](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html) policy PR #67 .
 - The RDS instance was destroyed by PR #83 , but it was backed up under the snapshot name: `covid-business-grants-db-production-updated-not-used-in-15mo-snapshot`.

# Screenshot:

| S3 bucket has Retain policy |
| --- |
| ![image](https://github.com/user-attachments/assets/da7db779-84b1-4f84-9a39-f52c6cbd47e6) |